### PR TITLE
Move update URL to Mod info

### DIFF
--- a/src/main/java/net/minecraftforge/forgespi/language/IModFileInfo.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IModFileInfo.java
@@ -22,7 +22,6 @@ package net.minecraftforge.forgespi.language;
 import com.electronwill.nightconfig.core.UnmodifiableConfig;
 import org.apache.maven.artifact.versioning.VersionRange;
 
-import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
@@ -31,8 +30,6 @@ public interface IModFileInfo
     List<IModInfo> getMods();
 
     UnmodifiableConfig getConfig();
-
-    URL getUpdateURL(IModFileInfo modFileInfo);
 
     String getModLoader();
 

--- a/src/main/java/net/minecraftforge/forgespi/language/IModInfo.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IModInfo.java
@@ -25,6 +25,7 @@ import net.minecraftforge.forgespi.Environment;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.VersionRange;
 
+import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
@@ -49,6 +50,8 @@ public interface IModInfo
     String getNamespace();
 
     Map<String,Object> getModProperties();
+
+    URL getUpdateURL();
 
 
     enum Ordering {


### PR DESCRIPTION
This changes the update json to per mod, as the jar does not have a version we can compare against, but the mod has. Forge implementation will follow