### PR TITLE
Adjust for MinecraftForge#6799

### DIFF
--- a/src/main/java/net/minecraftforge/forgespi/language/IModInfo.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IModInfo.java
@@ -83,5 +83,7 @@ public interface IModInfo
         void setOwner(IModInfo owner);
 
         IModInfo getOwner();
+        
+        URL getDisplayURL();
     }
 }


### PR DESCRIPTION
Add ModVersion#getDisplayUrl() so that a URL can be set for dependencies.

See MinecraftForge/MinecraftForge#6799