### PR TITLE
Add function that only returns a path if a file exists at the specified path

### DIFF
--- a/src/main/java/net/minecraftforge/forgespi/locating/IModLocator.java
+++ b/src/main/java/net/minecraftforge/forgespi/locating/IModLocator.java
@@ -21,6 +21,8 @@ package net.minecraftforge.forgespi.locating;
 
 import org.apache.commons.lang3.tuple.Pair;
 
+import javax.annotation.Nullable;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.CodeSigner;
 import java.util.List;
@@ -39,6 +41,18 @@ public interface IModLocator {
     String name();
 
     Path findPath(IModFile modFile, String... path);
+
+    /**
+     * This method functions like {@link #findPath(IModFile, String...)}, but returns {@code null} when the supplied path does not exist in the {@link IModFile} specified.
+     */
+    @Nullable
+    default Path findPathIfExists(IModFile modFile, String... path) {
+        Path ret = findPath(modFile, path);
+        if (Files.exists(ret))
+            return ret;
+        else
+            return null;
+    }
 
     void scanFile(final IModFile modFile, Consumer<Path> pathConsumer);
 


### PR DESCRIPTION
Adds a function to the IModLocator that returns a path object for the string path specified in the mod file specified if and only if the file exists. This function returns null if the path does not exist in the provided ModFile.
By default, it just checks the output from the old findPath using Files.exist. Custom implementations can override this with faster checking, as Files.exist can be quite slow compared to other methods, as it has to do some zip trickery in certain cases and needs to look at the FileSystem.