### PR TITLE
Add support for dependency locators

### DIFF
--- a/src/main/java/net/minecraftforge/forgespi/locating/IDependencyLocator.java
+++ b/src/main/java/net/minecraftforge/forgespi/locating/IDependencyLocator.java
@@ -1,0 +1,19 @@
+package net.minecraftforge.forgespi.locating;
+
+import java.util.List;
+
+/**
+ * Loaded as a ServiceLoader. Takes mechanisms for locating candidate "mod-dependencies".
+ * and transforms them into {@link IModFile} objects.
+ */
+public interface IDependencyLocator extends IModProvider
+{
+    /**
+     * Invoked to find all mod dependencies that this dependency locator can find.
+     * It is not guaranteed that all these are loaded into the runtime,
+     * as such the result of this method should be seen as a list of candidates to load.
+     *
+     * @return All found, or discovered, mod files which function as dependencies.
+     */
+    List<IModFile> scanMods(final Iterable<IModFile> loadedMods);
+}

--- a/src/main/java/net/minecraftforge/forgespi/locating/IModFile.java
+++ b/src/main/java/net/minecraftforge/forgespi/locating/IModFile.java
@@ -8,31 +8,118 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+/**
+ * Represents a single "mod" file in the runtime.
+ *
+ * Although these are known as "Mod"-Files, they do not always represent mods.
+ * However, they should be more treated as an extension or modification of minecraft.
+ * And as such can contain any number of things, like language loaders, dependencies of other mods
+ * or code which does not interact with minecraft at all and is just a utility for any of the other mod
+ * files.
+ */
 public interface IModFile {
+    /**
+     * The language loaders which are included in this mod file.
+     *
+     * If this method returns any entries then {@link #getType()} has to return {@link Type#LIBRARY},
+     * else this mod file will not be loaded in the proper module layer in 1.17 and above.
+     *
+     * As such, returning entries from this method is mutually exclusive with returning entries from {@link #getModInfos()}.
+     *
+     * @return The mod language providers provided by this mod file. (Also known as the loaders).
+     */
     List<IModLanguageProvider> getLoaders();
 
+    /**
+     * Invoked to find a particular resource in this mod file, with the given path.
+     *
+     * @param pathName The string representation of the path to find the mod resource on.
+     * @return The {@link Path} that represents the requested resource.
+     */
     Path findResource(String... pathName);
 
+    /**
+     * The mod files specific string data substitution map.
+     * The map returned here is used to interpolate values in the metadata of the included mods.
+     * Examples of where this is used in FML: While parsing the mods.toml file, keys like:
+     * ${file.xxxxx} are replaced with the values of this map, with keys xxxxx.
+     *
+     * @return The string substitution map used during metadata load.
+     */
     Supplier<Map<String,Object>> getSubstitutionMap();
 
+    /**
+     * The type of the mod jar.
+     * This primarily defines how and where this mod file is loaded into the module system.
+     *
+     * @return The type of the mod file.
+     */
     Type getType();
 
+    /**
+     * The path to the underlying mod file.
+     * @return The path to the mod file.
+     */
     Path getFilePath();
 
+    /**
+     * The secure jar that represents this mod file.
+     *
+     * @return The secure jar.
+     */
     SecureJar getSecureJar();
 
+    /**
+     * Sets the security status after verification of the mod file has been concluded.
+     * The security status is only determined if the jar is to be loaded into the runtime.
+     *
+     * @param status The new status.
+     */
     void setSecurityStatus(SecureJar.Status status);
 
+    /**
+     * Returns a list of all mods located inside this jar.
+     *
+     * If this method returns any entries then {@link #getType()} has to return {@link Type#MOD},
+     * else this mod file will not be loaded in the proper module layer in 1.17 and above.
+     *
+     * As such returning entries from this method is mutually exclusive with {@link #getLoaders()}.
+     *
+     * @return The mods in this mod file.
+     */
     List<IModInfo> getModInfos();
 
+    /**
+     * The metadata scan result of all the classes located inside this file.
+     *
+     * @return The metadata scan result.
+     */
     ModFileScanData getScanResult();
 
+    /**
+     * The raw file name of this file.
+     * @return The raw file name.
+     */
     String getFileName();
 
-    IModLocator getLocator();
+    /**
+     * The provider who provided the runtime with this jar.
+     * Implicitly indicates what caused the load of the PR. (Mod in mods directory, mod in dev environment, etc)
+     *
+     * @return The provider of this file.
+     */
+    IModProvider getProvider();
 
+    /**
+     * The metadata info related to this particular file.
+     * @return The info for this file.
+     */
     IModFileInfo getModFileInfo();
 
+    /**
+     * The type of file.
+     * Determines into which module layer the data is loaded and how metadata is loaded and processed.
+     */
     enum Type {
         /**
          * A mod file holds mod code and loads in the game module layer

--- a/src/main/java/net/minecraftforge/forgespi/locating/IModLocator.java
+++ b/src/main/java/net/minecraftforge/forgespi/locating/IModLocator.java
@@ -19,28 +19,20 @@
 
 package net.minecraftforge.forgespi.locating;
 
-import org.apache.commons.lang3.tuple.Pair;
-
-import java.nio.file.Path;
-import java.security.CodeSigner;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Consumer;
-import java.util.jar.Manifest;
 
 /**
  * Loaded as a ServiceLoader. Takes mechanisms for locating candidate "mods"
- * and transforms them into {@link ModFile} objects.
+ * and transforms them into {@link IModFile} objects.
  */
-public interface IModLocator {
+public interface IModLocator extends IModProvider
+{
+    /**
+     * Invoked to find all mods that this mod locator can find.
+     * It is not guaranteed that all these are loaded into the runtime,
+     * as such the result of this method should be seen as a list of candidates to load.
+     *
+     * @return All found, or discovered, mod files.
+     */
     List<IModFile> scanMods();
-
-    String name();
-
-    void scanFile(final IModFile modFile, Consumer<Path> pathConsumer);
-
-    void initArguments(Map<String, ?> arguments);
-
-    boolean isValid(IModFile modFile);
 }

--- a/src/main/java/net/minecraftforge/forgespi/locating/IModProvider.java
+++ b/src/main/java/net/minecraftforge/forgespi/locating/IModProvider.java
@@ -1,0 +1,42 @@
+package net.minecraftforge.forgespi.locating;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Describes objects which can provide mods (or related jars) to the loading runtime.
+ */
+public interface IModProvider
+{
+    /**
+     * The name of the provider.
+     * Has to be unique between all providers loaded into the runtime.
+     *
+     * @return The name.
+     */
+    String name();
+
+    /**
+     * Invoked to scan a particular {@link IModFile} for metadata.
+     *
+     * @param modFile The mod file to scan.
+     * @param pathConsumer A consumer which extracts metadata from the path given.
+     */
+    void scanFile(IModFile modFile, Consumer<Path> pathConsumer);
+
+    /**
+     * Invoked with the game startup arguments to allow for configuration of the provider.
+     *
+     * @param arguments The arguments.
+     */
+    void initArguments(Map<String, ?> arguments);
+
+    /**
+     * Indicates if the given mod file is valid.
+     *
+     * @param modFile The mod file in question.
+     * @return True to mark as valid, false otherwise.
+     */
+    boolean isValid(IModFile modFile);
+}

--- a/src/main/java/net/minecraftforge/forgespi/locating/ModFileFactory.java
+++ b/src/main/java/net/minecraftforge/forgespi/locating/ModFileFactory.java
@@ -4,12 +4,34 @@ import cpw.mods.jarhandling.SecureJar;
 import net.minecraftforge.forgespi.Environment;
 import net.minecraftforge.forgespi.language.IModFileInfo;
 
+/**
+ * A factory to build new mod file instances.
+ */
 public interface ModFileFactory {
+    /**
+     * The current instance. Equals to {@link Environment#getModFileFactory()}, of the current environment instance.
+     */
     ModFileFactory FACTORY = Environment.get().getModFileFactory();
-    IModFile build(final SecureJar jar, final IModLocator locator, ModFileInfoParser parser);
 
+    /**
+     * Builds a new mod file instance depending on the current runtime.
+     * @param jar The secure jar to load the mod file from.
+     * @param provider The provider which is offering the mod file for loading-
+     * @param parser The parser which is responsible for parsing the metadata of the file itself.
+     * @return The mod file.
+     */
+    IModFile build(final SecureJar jar, final IModProvider provider, ModFileInfoParser parser);
+
+    /**
+     * A parser specification for building a particular mod files metadata.
+     */
     interface ModFileInfoParser {
+        /**
+         * Invoked to get the freshly build mod files metadata.
+         *
+         * @param file The file to parse the metadata for.
+         * @return The mod file metadata info.
+         */
         IModFileInfo build(IModFile file);
     }
-
 }


### PR DESCRIPTION
### Description
This pull requests refactors the `IModLocator` concept.
Its primary goal is to support a second stage of mod loading, namely dependency loading.

The goal here is that the first stage discovers primary mods (in the mods folder, spl etc) and then this mod list is passed to a second stage. This second stage then can load additional dependencies based on the data from those already selected mods.

Just a side note here:
We might want to look into refactoring the "Mod" concept here in this project.
SPI Specifies everything as a "mod" and processes everything in that concept, but there are none mod jars out there that then could be loaded by this new system.

### Related to:
- MinecraftForge/securejarhandler#14
- MinecraftForge/MinecraftForge#8164