### PR TITLE
Introduce abstractions over `IModFile`

### DIFF
--- a/src/main/java/net/minecraftforge/forgespi/language/IModFileInfo.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IModFileInfo.java
@@ -25,27 +25,81 @@ import org.apache.maven.artifact.versioning.VersionRange;
 import java.util.List;
 import java.util.Map;
 
-public interface IModFileInfo
+/**
+ * Represents the collected info on a mod file.
+ */
+public interface IModFileInfo extends IConfigurable
 {
+    /**
+     * Returns the mods which can be found in the mod file.
+     *
+     * @return The information on the mods that can be found in the file.
+     */
     List<IModInfo> getMods();
 
+    /**
+     * Defines the combination of required language and supported version range.
+     * Used during loading to determine if the mod file is compatible with the current environment.
+     *
+     * @param languageName The name of the runtime language that is needed.
+     * @param acceptedVersions The accepted version range.
+     */
     record LanguageSpec(String languageName, VersionRange acceptedVersions) {}
 
+    /**
+     * Returns the languages that are required by the mod file.
+     *
+     * @return The required languages.
+     */
     List<LanguageSpec> requiredLanguageLoaders();
 
+    /**
+     * Indicates if this mod file should be shown as a resource pack or not.
+     *
+     * @return {@code true} if the mod file should be shown as a resource pack, {@code false} otherwise.
+     */
     boolean showAsResourcePack();
 
+    /**
+     * Returns the mod files own properties.
+     *
+     * @return The custom properties of the mod file.
+     */
     Map<String,Object> getFileProperties();
 
-    String getLicense();
-
+    /**
+     * The java module name of the file.
+     * Note: This needs to adhere to the JVM specification.
+     *
+     * @return The module name.
+     */
     String moduleName();
 
+    /**
+     * The version of this module as a string.
+     *
+     * @return The version of this module.
+     */
     String versionString();
 
+    /**
+     * Indicates which services this mod file requires.
+     *
+     * @return The services that this mod file requires.
+     */
     List<String> usesServices();
 
+    /**
+     * The underlying mod file.
+     *
+     * @return The mod file.
+     */
     IModFile getFile();
 
+    /**
+     * The underlying configuration of this mod file info object.
+     *
+     * @return The configuration of this mod file info object.
+     */
     IConfigurable getConfig();
 }

--- a/src/main/java/net/minecraftforge/forgespi/language/IModFileInfoWithLicense.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IModFileInfoWithLicense.java
@@ -1,0 +1,22 @@
+package net.minecraftforge.forgespi.language;
+
+/**
+ * Represents mod files which have an included license.
+ * Ensure that the forge license validation code can check for a valid license on mod files which support it.
+ */
+public interface IModFileInfoWithLicense extends IModFileInfo
+{
+    /**
+     * Returns the license name of the mod file.
+     *
+     * @return The license name of the mod file.
+     */
+    String getLicense();
+
+    /**
+     * Indicates if the mod file has a license, or not.
+     *
+     * @return {@code true} if the mod file has a license, {@code false} otherwise.
+     */
+    boolean isMissingLicense();
+}

--- a/src/main/java/net/minecraftforge/forgespi/language/IModFileWithAccessTransformer.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IModFileWithAccessTransformer.java
@@ -1,0 +1,18 @@
+package net.minecraftforge.forgespi.language;
+
+import net.minecraftforge.forgespi.locating.IModFile;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Represents a mod file which has an access transformer embedded in it.
+ */
+public interface IModFileWithAccessTransformer extends IModFile
+{
+    /**
+     * Gets the access transformer file path for this mod file.
+     * @return The access transformer file path for this mod file.
+     */
+    Optional<Path> getAccessTransformer();
+}

--- a/src/main/java/net/minecraftforge/forgespi/language/IModFileWithCoreMods.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IModFileWithCoreMods.java
@@ -1,0 +1,20 @@
+package net.minecraftforge.forgespi.language;
+
+import net.minecraftforge.forgespi.coremod.ICoreModFile;
+import net.minecraftforge.forgespi.locating.IModFile;
+
+import java.util.List;
+
+/**
+ * Represents a mod file that has a list of core mods that are required to be loaded.
+ */
+public interface IModFileWithCoreMods extends IModFile
+{
+
+    /**
+     * Gets the list of core mods that are required to be loaded.
+     *
+     * @return The list of core mods that are required to be loaded.
+     */
+    List<? extends ICoreModFile> getCoreMods();
+}

--- a/src/main/java/net/minecraftforge/forgespi/language/IModFileWithJarVersion.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IModFileWithJarVersion.java
@@ -1,0 +1,17 @@
+package net.minecraftforge.forgespi.language;
+
+import net.minecraftforge.forgespi.locating.IModFile;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+
+/**
+ * Represents a mod file that has a version in the jar.
+ */
+public interface IModFileWithJarVersion extends IModFile
+{
+    /**
+     * Gets the version of the mod file.
+     *
+     * @return The version of the mod file.
+     */
+    ArtifactVersion getJarVersion();
+}

--- a/src/main/java/net/minecraftforge/forgespi/language/IModFileWithModDiscoveryCapabilities.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IModFileWithModDiscoveryCapabilities.java
@@ -1,0 +1,21 @@
+package net.minecraftforge.forgespi.language;
+
+/**
+ * Represents a mod file that can be discovered by the mod discovery system.
+ */
+public interface IModFileWithModDiscoveryCapabilities extends IModFileWithCoreMods, IModFileWithAccessTransformer, IScannableModFile, IModFileWithProperties, IModFileWithJarVersion
+{
+    /**
+     * Invoked by the discovery system to identify the mods that are located in this file and populate their metadata.
+     * Note: this can be called from any thread.
+     *
+     * @return {@code true} when a mod was found, {@code false} otherwise.
+     */
+    boolean identifyMods();
+
+    /**
+     * Invoked by the discovery system to identify the runtime languages and flavors which are needed to potentially run mods in this file.
+     * Note: this can be called from any thread.
+     */
+    void identifyLanguage();
+}

--- a/src/main/java/net/minecraftforge/forgespi/language/IModFileWithProperties.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IModFileWithProperties.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.forgespi.language;
+
+import net.minecraftforge.forgespi.locating.IModFile;
+
+import java.util.Map;
+
+/**
+ * Interface for mod files that have properties.
+ * Allows for both the reading and the writing of the associated properties of the mod file.
+ */
+public interface IModFileWithProperties extends IModFile
+{
+    /**
+     * The current properties of the mod file.
+     * Note: Might be immutable.
+     *
+     * @return The properties of the mod file.
+     */
+    Map<String, Object> getFileProperties();
+
+    /**
+     * Sets the properties of the mod file.
+     *
+     * @param fileProperties The properties of the mod file.
+     */
+    void setFileProperties(Map<String, Object> fileProperties);
+}

--- a/src/main/java/net/minecraftforge/forgespi/language/IScannableModFile.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IScannableModFile.java
@@ -1,0 +1,40 @@
+package net.minecraftforge.forgespi.language;
+
+import net.minecraftforge.forgespi.locating.IModFile;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+/**
+ * Represents a mod file that can be scanned for annotation data.
+ */
+public interface IScannableModFile extends IModFile
+{
+    /**
+     * Invoked to scan the mod file for annotation data.
+     *
+     * @param pathConsumer The path consumer which can scan a class file for annotation data.
+     */
+    void scanFile(Consumer<Path> pathConsumer);
+
+    /**
+     * Run in an executor thread to harvest the class and annotation list.
+     */
+    ModFileScanData compileContent();
+
+    /**
+     * Invoked to set the scan result which is potentially being computed off-thread.
+     *
+     * @param future The future to complete when the scan is complete.
+     */
+    void setFutureScanResult(CompletableFuture<ModFileScanData> future);
+
+    /**
+     * Invoked to set the scan result after it has been computed, and optionally an exception if the scan failed.
+     *
+     * @param modFileScanData The scan result.
+     * @param throwable The exception if the scan failed.
+     */
+    void setScanResult(ModFileScanData modFileScanData, Throwable throwable);
+}


### PR DESCRIPTION
The introduced interfaces will be used in conjuction with the JiJ infrastructure to provide a better handling of the loading stages inside of forge it self.

Each added interface, more or less, represents a loading stage inside of forge and is used to handle it there in particularly. Up untill this PR loading infrastructure needed a harddep on either forge or fmlloader to gain access to classes like `ModFile` which was required since casts where performed in between to gain access to isolated data which was only available inside of `ModFile` with this PR in place we one step closer to a more isolated loading process.