### PR TITLE
Add `IModFileInfo#isClientSideOnly`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import net.minecraftforge.gradleutils.PomUtils
 
 plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
-    id 'net.minecraftforge.gradleutils' version '2.+'
+    id 'net.minecraftforge.gradleutils' version '[2.2,2.3)'
     id 'maven-publish'
     id 'java-library'
 }

--- a/src/main/java/net/minecraftforge/forgespi/language/IModFileInfo.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IModFileInfo.java
@@ -19,6 +19,10 @@ public interface IModFileInfo {
 
     boolean showAsResourcePack();
 
+    default boolean isClientSideOnly() {
+        return false;
+    }
+
     Map<String,Object> getFileProperties();
 
     String getLicense();

--- a/src/main/java/net/minecraftforge/forgespi/language/IModFileInfo.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IModFileInfo.java
@@ -19,6 +19,10 @@ public interface IModFileInfo {
 
     boolean showAsResourcePack();
 
+    /**
+     * Indicates if this mod file is only intended for physical clients.
+     * <p>When true, the loader will skip loading this mod file on dedicated servers.</p>
+     */
     default boolean isClientSideOnly() {
         return false;
     }

--- a/src/main/java/net/minecraftforge/forgespi/language/ModFileScanData.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/ModFileScanData.java
@@ -20,7 +20,7 @@ public class ModFileScanData {
     private final Set<AnnotationData> annotations = new LinkedHashSet<>();
     private final Set<ClassData> classes = new LinkedHashSet<>();
     private final Map<String,IModLanguageProvider.IModLanguageLoader> modTargets = new HashMap<>();
-    private List<IModFileInfo> modFiles = new ArrayList<>();
+    private final List<IModFileInfo> modFiles = new ArrayList<>();
 
     @Deprecated(forRemoval = true, since = "7.1")
     public static Predicate<Type> interestingAnnotations() {


### PR DESCRIPTION
Some mod devs don't properly understand class loading and are unaware of how easily they can crash servers on launch if they reference client-only classes. While ideally mod devs should spend the time to figure it out properly, giving them a simple, optional one-liner in their mods.toml could drastically cut down on the amount of mods that fall into this trap.

This is false by default and not required to be set. When true, we could skip attempting to load the mod entirely during the discovery stage as well as set an appropriate display test - this not only helps prevent crashing servers, but also fixes false-positives from forgetting to set the display test correctly.

The reason this is a boolean for client rather than a `Dist` is because server-side mods are expected to work on integrated servers and "Open to LAN".