### PR TITLE
Enhance IConfigurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ tasks.named('jar', Jar).configure {
 dependencies {
     implementation('org.apache.logging.log4j:log4j-api:2.17.0')
     // Needed for Type
-    implementation('org.ow2.asm:asm:9.6')
+    implementation('org.ow2.asm:asm:9.7')
     // Needed for dependency version comparisons
     implementation('org.apache.maven:maven-artifact:3.8.1')
     // Needed for SecureJar API class

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ dependencies {
     implementation('net.minecraftforge:securemodules:2.2.2')
     // Needed for IEnvironment and ITransformer API
     implementation('net.minecraftforge:modlauncher:10.1.1')
+    // Needed for Nullable annotation
+    implementation('org.jetbrains:annotations:24.1.0')
     // Needed for the sided markers
     api('net.minecraftforge:mergetool-api:1.0')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,6 @@ dependencies {
     implementation('net.minecraftforge:securemodules:2.2.2')
     // Needed for IEnvironment and ITransformer API
     implementation('net.minecraftforge:modlauncher:10.1.1')
-    // Needed for Nullable annotation
-    implementation('org.jetbrains:annotations:24.1.0')
     // Needed for the sided markers
     api('net.minecraftforge:mergetool-api:1.0')
 }

--- a/src/main/java/net/minecraftforge/forgespi/language/IConfigurable.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IConfigurable.java
@@ -6,7 +6,6 @@ package net.minecraftforge.forgespi.language;
 
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,7 +31,5 @@ public interface IConfigurable {
         return getConfigList(new String[] { key });
     }
 
-    default List<? extends IConfigurable> getConfigList(String... key) {
-        return Collections.emptyList();
-    }
+    List<? extends IConfigurable> getConfigList(String... key);
 }

--- a/src/main/java/net/minecraftforge/forgespi/language/IConfigurable.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IConfigurable.java
@@ -17,14 +17,6 @@ public interface IConfigurable {
 
     <T> Optional<T> getConfigElement(String... key);
 
-    default <T> T getNullableConfigElement(String key) {
-        return this.<T>getConfigElement(key).orElse(null);
-    }
-
-    default <T> T getNullableConfigElement(String... key) {
-        return this.<T>getConfigElement(key).orElse(null);
-    }
-
     default List<? extends IConfigurable> getConfigList(String key) {
         return getConfigList(new String[] { key });
     }

--- a/src/main/java/net/minecraftforge/forgespi/language/IConfigurable.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IConfigurable.java
@@ -4,6 +4,9 @@
  */
 package net.minecraftforge.forgespi.language;
 
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -11,6 +14,25 @@ import java.util.Optional;
  * This is an interface for querying configuration elements
  */
 public interface IConfigurable {
-    <T> Optional<T> getConfigElement(final String... key);
-    public List<? extends IConfigurable> getConfigList(final String... key);
+    default <T> Optional<T> getConfigElement(String key) {
+        return getConfigElement(new String[] { key });
+    }
+
+    <T> Optional<T> getConfigElement(String... key);
+
+    default <T> @Nullable T getNullableConfigElement(String key) {
+        return this.<T>getConfigElement(key).orElse(null);
+    }
+
+    default <T> @Nullable T getNullableConfigElement(String... key) {
+        return this.<T>getConfigElement(key).orElse(null);
+    }
+
+    default List<? extends IConfigurable> getConfigList(String key) {
+        return getConfigList(new String[] { key });
+    }
+
+    default List<? extends IConfigurable> getConfigList(String... key) {
+        return Collections.emptyList();
+    }
 }

--- a/src/main/java/net/minecraftforge/forgespi/language/IConfigurable.java
+++ b/src/main/java/net/minecraftforge/forgespi/language/IConfigurable.java
@@ -4,8 +4,6 @@
  */
 package net.minecraftforge.forgespi.language;
 
-import org.jetbrains.annotations.Nullable;
-
 import java.util.List;
 import java.util.Optional;
 
@@ -19,11 +17,11 @@ public interface IConfigurable {
 
     <T> Optional<T> getConfigElement(String... key);
 
-    default <T> @Nullable T getNullableConfigElement(String key) {
+    default <T> T getNullableConfigElement(String key) {
         return this.<T>getConfigElement(key).orElse(null);
     }
 
-    default <T> @Nullable T getNullableConfigElement(String... key) {
+    default <T> T getNullableConfigElement(String... key) {
         return this.<T>getConfigElement(key).orElse(null);
     }
 


### PR DESCRIPTION
This PR adds methods that allows implementors to avoid unnecessarily boxing the key in an array.

This change would allow me to improve the efficiency of ModInfo, ModFileInfo and ModVersion in Forge.